### PR TITLE
[CLOUD-3055] Change base layer to RHEL

### DIFF
--- a/tomcat9/image.yaml
+++ b/tomcat9/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: "jboss-webserver-5/webserver50-tomcat9"
 description: "Red Hat JBoss Web Server 5.0 Tomcat 9 container image"
 version: "5.0.1"
-from: "jboss/openjdk18-rhel7:1.1"
+from: "rhel7:7-released"
 labels:
     - name: "com.redhat.component"
       value: "jboss-webserver-5-webserver50-tomcat9-container"
@@ -50,8 +50,14 @@ ports:
       expose: false
 modules:
       repositories:
+          - name: cct_module
+            git:
+                url: https://github.com/jboss-openshift/cct_module.git
+                ref: master
           - path: modules
       install:
+          - name: jboss.container.openjdk.jdk
+            version: "8"
           - name: jws-unpack-tomcat9
           - name: jws-chown
           - name: jws-debugging


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3055

This changes the base image from the deprecated jboss/openjdk-rhel7
image (no longer being rebuilt) to plain RHEL, and pulls in the JDK
Cekit module that effectively implements the changes that were made
in the jboss/openjdk-rhel7 layer.

Signed-off-by: Jonathan Dowland <jdowland@redhat.com>