### PR TITLE
Removed openj9 rpm packages to install from the latest repo

### DIFF
--- a/tomcat9/overrides.yaml
+++ b/tomcat9/overrides.yaml
@@ -9,10 +9,6 @@ osbs:
     container:
       compose:
         inherit: true
-        packages:
-        - java-11-openj9
-        - java-11-openj9-devel
-        - java-11-openj9-headless
         pulp_repos: true
         signing_intent: release
       platforms:


### PR DESCRIPTION
Openj9 rpm packages are currently declared explicitly in the overrides.yaml file and therefore overrides the latest openj9 rpms repository added to the content_sets.yml file. This prevents installing the packages from the latest repo. Removing the packages from the overrides.yaml file resolves this issue and installs from the latest openj9 rpms repository.